### PR TITLE
Improve README clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,66 @@
-# FLUX.1 Kontext (Cog inference)
+# FLUX.1 Kontext
 
-Compact Cog wrapper around Black Forest Labs' FLUX.1 *Kontext* dev model.  It loads the
-Transformer, auto-encoder, CLIP/T5 text encoders, and optional NSFW safety checker,
-then exposes a single `predict` endpoint that performs image-to-image editing or
-style transfer conditioned on a text prompt.
+This repository wraps the **FLUX.1 Kontext** image‑to‑image model in a simple
+[Cog](https://github.com/replicate/cog) predictor.  It loads the transformer, auto
+encoder and text encoders and exposes a single `predict` function for applying
+edits or style transfer to an input image.
+
+FLUX.1 Kontext is an experimental model from Black Forest Labs.  The code in this
+repository is licensed under Apache‑2.0.  See the model card for FLUX.1’s own
+licence.
+
+## Quick start
+
+The easiest way to run the model is with Cog.  First install Cog and then run:
 
 ```bash
-# basic usage
 cog predict -i prompt="make the hair blue" -i input_image=@lady.png
 ```
 
-Everything required (weights download, Torch 2 compilation, etc.) happens
-automatically on first run.
+All required model weights are downloaded automatically the first time you run
+it.  The predictor uses `torch.compile` and caches the compiled model for faster
+subsequent runs.
 
-Licensed under Apache-2.0 for the wrapper code; see model card for FLUX.1 license.
+## Running the demo UI
 
-### Performance Optimizations
-- `torch.compile` is used in dynamic mode
-- the two linear layers in the single stream block are quantized to run in FP8, using a modified version of aredden's [fp8 linear layer](https://github.com/aredden/flux-fp8-api/blob/main/float8_quantize.py)
-- [taylor seer](https://arxiv.org/abs/2503.06923) style activation caching, enabled by the `go_fast` option in the cog predictor. May cause quality degradation for more complex editing tasks.
-- enable pytorch's cudnn attention backend
+A small [Gradio](https://gradio.app) demo is provided in `app.py`.  Launch it with:
+
+```bash
+python app.py
+```
+
+This starts a local web interface where you can experiment with different
+prompts, aspect ratios and other options without using Cog directly.
+
+## Predictor options
+
+When calling `predict.py` (either via Cog or from another Python script) you can
+control several parameters:
+
+- `prompt` – text instruction describing how to modify the input image
+- `input_image` – path to the source image (jpg, png, gif or webp)
+- `aspect_ratio` – aspect ratio of the output. `match_input_image` keeps the
+  original ratio
+- `num_inference_steps` – number of denoising steps (4–50)
+- `guidance` – guidance scale controlling prompt strength
+- `seed` – optional random seed for repeatable results
+- `output_format` – one of `webp`, `jpg` or `png`
+- `output_quality` – quality value for jpg/webp outputs
+- `disable_safety_checker` – skip NSFW filtering
+- `go_fast` – enable the Taylor‐seer style cache for faster but potentially
+  lower quality output
+
+Calling the predictor returns the path to the generated image.
+
+## Precompiling Torch code
+
+The script `generate_torch_compile_cache.py` can be used to pre‑generate the
+`torch.compile` cache so that the first inference call is faster.  This is
+optional – if the cache file is absent the predictor will build it on the first
+run.
+
+## License
+
+The wrapper code in this repository is released under the Apache‑2.0 license.
+Model weights are provided by Black Forest Labs and are subject to their own
+terms.


### PR DESCRIPTION
## Summary
- rewrite README with complete usage instructions

## Testing
- `python -m py_compile predict.py util.py weights.py safety_checker.py app.py generate_torch_compile_cache.py`
- `python test_predictor.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686376a83cf8832b82699881a4c87546