### PR TITLE
Fix Path import for cross-platform support

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
 import gradio as gr
 from PIL import Image
-from cog import Path
+try:
+    from cog import Path  # type: ignore
+except Exception:  # pragma: no cover - fallback for non-cog environments
+    from pathlib import Path
 
 from predict import FluxDevKontextPredictor
 from flux.util import ASPECT_RATIOS

--- a/predict.py
+++ b/predict.py
@@ -2,7 +2,11 @@ import os
 import time
 import torch
 from PIL import Image
-from cog import BasePredictor, Path, Input
+from cog import BasePredictor, Input
+try:
+    from cog import Path  # type: ignore
+except Exception:  # pragma: no cover - fallback for non-cog environments
+    from pathlib import Path
 
 from flux.sampling import denoise, get_schedule, prepare_kontext, unpack
 from flux.util import (

--- a/safety_checker.py
+++ b/safety_checker.py
@@ -9,7 +9,10 @@ from transformers import (
     AutoModelForImageClassification,
     ViTImageProcessor,
 )
-from cog import Path
+try:
+    from cog import Path  # type: ignore
+except Exception:  # pragma: no cover - fallback for non-cog environments
+    from pathlib import Path
 
 from weights import download_weights
 from util import print_timing

--- a/test_predictor.py
+++ b/test_predictor.py
@@ -8,7 +8,10 @@ This script imports the predictor, sets it up, and calls predict with all aspect
 # os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
 
 from predict import FluxDevKontextPredictor
-from cog import Path
+try:
+    from cog import Path  # type: ignore
+except Exception:  # pragma: no cover - fallback for non-cog environments
+    from pathlib import Path
 import time
 
 


### PR DESCRIPTION
## Summary
- fall back to `pathlib.Path` when `cog.Path` isn't available

## Testing
- `python test_predictor.py` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_686467fed614832bbea0b0e0da975616