### PR TITLE
Fix Path import on Windows

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
 import gradio as gr
 from PIL import Image
+import os
 try:
+    if os.name == "nt":
+        raise ImportError
     from cog import Path  # type: ignore
 except Exception:  # pragma: no cover - fallback for non-cog environments
     from pathlib import Path

--- a/predict.py
+++ b/predict.py
@@ -3,7 +3,10 @@ import time
 import torch
 from PIL import Image
 from cog import BasePredictor, Input
+
 try:
+    if os.name == "nt":
+        raise ImportError
     from cog import Path  # type: ignore
 except Exception:  # pragma: no cover - fallback for non-cog environments
     from pathlib import Path

--- a/safety_checker.py
+++ b/safety_checker.py
@@ -9,7 +9,11 @@ from transformers import (
     AutoModelForImageClassification,
     ViTImageProcessor,
 )
+import os
+
 try:
+    if os.name == "nt":
+        raise ImportError
     from cog import Path  # type: ignore
 except Exception:  # pragma: no cover - fallback for non-cog environments
     from pathlib import Path

--- a/test_predictor.py
+++ b/test_predictor.py
@@ -8,7 +8,10 @@ This script imports the predictor, sets it up, and calls predict with all aspect
 # os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
 
 from predict import FluxDevKontextPredictor
+import os
 try:
+    if os.name == "nt":
+        raise ImportError
     from cog import Path  # type: ignore
 except Exception:  # pragma: no cover - fallback for non-cog environments
     from pathlib import Path


### PR DESCRIPTION
## Summary
- import `pathlib.Path` on Windows to avoid NotImplementedError
- apply the fix in `predict.py`, `safety_checker.py`, `app.py`, and `test_predictor.py`

## Testing
- `python -m py_compile app.py predict.py safety_checker.py test_predictor.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68646a500e98832bbc77739a2b3dc73f