### PR TITLE
Improve weight download reliability

### DIFF
--- a/weights.py
+++ b/weights.py
@@ -13,14 +13,36 @@ def download_weights(url: str, dest: Path):
 
     dest = Path(dest)
 
-    def _download_file(source: str, target: Path) -> None:
-        """Stream ``source`` to ``target`` using ``requests``."""
-        response = requests.get(source, stream=True)
-        response.raise_for_status()
-        with open(target, "wb") as fh:
-            for chunk in response.iter_content(chunk_size=1024 * 1024):
-                if chunk:
-                    fh.write(chunk)
+    def _download_file(source: str, target: Path, retries: int = 3) -> None:
+        """Stream ``source`` to ``target`` using ``requests`` with simple resume"""
+
+        bytes_downloaded = target.stat().st_size if target.exists() else 0
+        mode = "ab" if bytes_downloaded else "wb"
+        headers = {"Range": f"bytes={bytes_downloaded}-"} if bytes_downloaded else {}
+
+        while retries > 0:
+            try:
+                response = requests.get(
+                    source, stream=True, headers=headers, timeout=60
+                )
+                response.raise_for_status()
+                with open(target, mode) as fh:
+                    for chunk in response.iter_content(chunk_size=1024 * 1024):
+                        if chunk:
+                            fh.write(chunk)
+                return
+            except (
+                requests.exceptions.ChunkedEncodingError,
+                requests.exceptions.ConnectionError,
+            ) as e:
+                retries -= 1
+                print(f"Download interrupted: {e}, retries left: {retries}")
+                time.sleep(5)
+                bytes_downloaded = target.stat().st_size if target.exists() else 0
+                mode = "ab"
+                headers = {"Range": f"bytes={bytes_downloaded}-"}
+
+        raise RuntimeError("Failed to download weights after multiple attempts")
 
     # If the URL points to a tar archive we download to a temporary file and
     # extract it into the destination directory.  Otherwise we download the file
@@ -31,10 +53,13 @@ def download_weights(url: str, dest: Path):
             tmp_path = Path(tmp.name)
         _download_file(url, tmp_path)
         with tarfile.open(tmp_path) as tar:
+
             def is_within_directory(directory: str, target: str) -> bool:
                 abs_directory = Path(directory).resolve()
                 abs_target = Path(target).resolve()
-                return abs_directory in abs_target.parents or abs_directory == abs_target
+                return (
+                    abs_directory in abs_target.parents or abs_directory == abs_target
+                )
 
             for member in tar.getmembers():
                 member_path = dest / member.name


### PR DESCRIPTION
## Summary
- add resume support with retries when downloading weight files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_686481aae560832bb8ab2f383bbe5760