### PR TITLE
Load models on CPU before moving to GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ cog predict -i prompt="make the hair blue" -i input_image=@lady.png
 ```
 
 All required model weights are downloaded from Replicate the first time you run
-the predictor and cached under `models/`. The predictor uses `torch.compile`
-and stores the compiled model so subsequent runs are faster.
+the predictor and cached under `models/`. To reduce GPU memory usage at start-up
+the T5 encoder, CLIP embedder, Kontext transformer and autoencoder are loaded on
+the CPU and moved to the GPU after initialisation. The predictor uses
+`torch.compile` and stores the compiled model so subsequent runs are faster.
 
 ## Running the demo UI
 


### PR DESCRIPTION
## Summary
- load t5, clip, Kontext and autoencoder on the CPU first
- move models to GPU after loading and document new startup behavior

## Testing
- `python -m py_compile predict.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864edec6d40832b8e178d4afe11c145